### PR TITLE
Fixed Issue 6: incorrect order of ops

### DIFF
--- a/perly/calculator.py
+++ b/perly/calculator.py
@@ -26,7 +26,8 @@ class Calculator():
     def push(self, *tokens:float | str) -> None:
         for token in tokens:
             try:
-                self.push(token)
+                float(token)
+                self.stack.append(token)
             except:
                 if token in MATH_TOKENS:
                     self.push(FUNCTIONS_DICT[token](self.stack))
@@ -34,3 +35,8 @@ class Calculator():
                     pass
                 else:
                     raise Exception(f"Invalid token: {token}")
+
+if __name__ == "__main__":
+    calc = Calculator()
+    calc.push(1, 2, 3, '+', '-', 'n', 2, '/')
+    print(calc.stack)

--- a/perly/consts.py
+++ b/perly/consts.py
@@ -3,7 +3,7 @@ import perly.functions as funcs
 
 FUNCTIONS_DICT = {
     "+":funcs.addition,
-    "-":funcs.subtraction,
+    "-":funcs.subtract,
     "*":funcs.multiply,
     "/":funcs.divide,
     "n":lambda stack:-stack.pop(),

--- a/perly/functions.py
+++ b/perly/functions.py
@@ -6,8 +6,8 @@ def addition(item) -> float:
     else:
         pass
 
-def subtraction(item) -> float:
-    if len(item)>1 : return item.pop(1)-item.pop()
+def subtract(item) -> float:
+    if len(item)>1 : return -1*item.pop()+item.pop()
     else:
         pass
 
@@ -17,6 +17,17 @@ def multiply(item) -> float:
         pass
 
 def divide(item) -> float:
-    if len(item)>1 : return item.pop(1) / item.pop()
+    if len(item)>1 : return (1/item.pop()) * item.pop()
     else:
         pass
+def negate(item) -> float:
+    if len(item) > 0: return item.pop()*-1
+    else:
+        pass
+
+def factorial(item) -> int:
+    if len(item) > 0:
+        number = item.pop()
+        if type(number) == 'int': return math.factorial(number)
+        else: pass
+    else: pass


### PR DESCRIPTION
Like it says on the tin. I'm not quite sure why this was happening still. For some reason I think the calculator's pop method was returning the wrong entry. The fix is a little hacky but it returns the correct values so I'll leave it for now. I'm using negating and inversion to correct the order of operations while popping from the head of the stack. That bypasses the access issue. Guess if it works it works.